### PR TITLE
Adding the option to use local ROS time for time-stamping

### DIFF
--- a/config/param.yaml
+++ b/config/param.yaml
@@ -8,6 +8,7 @@ pixel_format: "RGB888" #pixel format documentation: https://libcamera.org/api-ht
 resolution:
   width: 1456
   height: 1088
+use_ros_time: true #If set to true, the time stamps of the output camera images will be expressed in the current ROS time, rather than the time given by the camera sensor
 
 #frame_id and calib_url parameters are set using launch file
 

--- a/src/LibcameraRos.cpp
+++ b/src/LibcameraRos.cpp
@@ -172,6 +172,7 @@ namespace libcamera_ros
     success = success && getCompulsoryParamCheck(nh_, "LibcameraRos", "calib_url", calib_url);
     success = success && getCompulsoryParamCheck(nh_, "LibcameraRos", "resolution/width", resolution_width);
     success = success && getCompulsoryParamCheck(nh_, "LibcameraRos", "resolution/height", resolution_height);
+    success = success && getCompulsoryParamCheck(nh_, "LibcameraRos", "use_ros_time", _use_ros_time_);
 
     if (!success)
     {
@@ -357,9 +358,6 @@ namespace libcamera_ros
     }
     if (getOptionalParamCheck(nh_, "LibcameraRos", "control/control", param_string)){
       updateControlParameter(pv_to_cv(get_ae_exposure_mode(param_string), parameter_ids_["AeExposureMode"]->type()), parameter_ids_["AeExposureMode"]);
-    }
-    if (getOptionalParamCheck(nh_, "LibcameraRos", "control/ros_time", param_bool)){
-      _use_ros_time_ = param_bool;
     }
 
     // allocate stream buffers and create one request per buffer


### PR DESCRIPTION
The default behavior retrieves time stamps directly from the camera, with no consideration for the actual current ROS time.
This was causing synchronization issues for a camera that arbitrarily tracks its own time, seemingly with zero at the time of device connection.
When the parameter `control/ros_time` is set to true, the driver will now first retrieve the timestamp difference of the first retrieved image, and then keep adding this to the rest.
Possible issues may arise, if the internal clock speed of the camera is slower or faster than the host computer, but I will address this if such issue occurs. 