### PR TITLE
Improve camera selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,28 +156,6 @@ ros2 launch libcamera_ros_driver stereo.launch.py \
   right_name:=back  right_custom_config:=/abs/path/camera_right.yaml right_calib_url:="file:///abs/path/back_calib.yaml"
 ```
 
-### Selecting which sensor a node uses
-
-By index:
-
-```yaml
-libcamera_ros_driver:
-  camera_name: ""   # empty disables name matching
-  camera_id: 0      # 0 / 1
-```
-
-or by the unique i2c path (robust across reboots; see the `dtoverlay ...,cam0/cam1` setup
-in `/boot/firmware/config.txt`):
-
-```yaml
-libcamera_ros_driver:
-  camera_name: "i2c@80000"   # / "i2c@88000"
-```
-
-Minimal per-camera overrides ship as `config/camera_left.yaml` / `config/camera_right.yaml`.
-
----
-
 ## Configuration
 
 Parameters resolve in this order (first match wins):

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ amd64 is convenient for development. Built and tested against **ROS 2 Jazzy**.
 ### Single camera
 
 ```bash
-ros2 launch libcamera_ros_driver camera.launch.py camera_name:=front
+ros2 launch libcamera_ros_driver camera.launch.py prefix:=front
 # then verify:
 ros2 topic hz /uav1/rpi_camera_front/image_raw
 ```
@@ -140,9 +140,9 @@ different camera:
 
 ```bash
 ros2 launch libcamera_ros_driver camera.launch.py \
-  camera_name:=front custom_config:=/abs/path/camera_left.yaml
+  prefix:=left custom_config:=/abs/path/camera_left.yaml
 ros2 launch libcamera_ros_driver camera.launch.py \
-  camera_name:=back  custom_config:=/abs/path/camera_right.yaml
+  prefix:=right  custom_config:=/abs/path/camera_right.yaml
 ```
 
 > You cannot acquire the **same physical camera** from two processes, each launch must

--- a/config/camera_left.yaml
+++ b/config/camera_left.yaml
@@ -1,17 +1,12 @@
 libcamera_ros_driver:
 
-  # This is the camera index in the list of cameras returned by libcamera.
-  # The order of cameras in the list is not stable, so this should never be used and is here just for backwards compatibility.
-  # Use camera_name instead.
-  camera_id: 0
-
-  # Camera name is the key used to identify the camera based on it's hardware ID when camera_id is not used (camera_id = -1).
-  # To get a list of available cameras, run `libcamera-hello --list-cameras` to get something like this:
+  # Camera name is the key used to identify the camera based on it's device tree path.
+  # To get a list of available cameras, run `libcamera-hello --list-cameras`. You will see something like this:
   #   /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60
   #   /base/axi/pcie@1000120000/rp1/i2c@88000/ov9281@60
-  # You can use any part of the camera's hardware ID as the camera_name, as long as it is unique among all cameras on the system.
-  #   if you only have one camera, you can put leave this as empty string (""), so it matches the first camera found on the system.
+  # You can use any part of the camera's device tree path as the camera_name, as long as it is unique among all cameras on the system.
+  #   if you only have one camera, you can leave this as empty string (""), so it matches the first camera found.
   #   if you have different camera models, then the model name is a good choice (such as ov9281)
   #   if you have multiple cameras of the same type, then you can use the address (such as i2c@80000)
-  #   if you want to be really sure to use a specific camera, you can use the full hardware ID (such as /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60)
+  #   if you want to be really sure to use a specific camera, you can use the full device tree path (such as /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60)
   camera_name: ""

--- a/config/camera_left.yaml
+++ b/config/camera_left.yaml
@@ -1,13 +1,17 @@
 libcamera_ros_driver:
 
-  # Per-camera override for the LEFT sensor of a stereo pair.
-  # Loaded as custom_config (after default.yaml), so these keys win.
-  #
-  # Select by index (robust default): empty camera_name disables name matching,
-  # so camera_id is used verbatim.
-  camera_name: ""
+  # This is the camera index in the list of cameras returned by libcamera.
+  # The order of cameras in the list is not stable, so this should never be used and is here just for backwards compatibility.
+  # Use camera_name instead.
   camera_id: 0
 
-  # Alternative: select by the unique i2c path (see config.txt dtoverlay cam0/cam1).
-  # Comment out the two lines above and use, e.g.:
-  # camera_name: "i2c@80000"
+  # Camera name is the key used to identify the camera based on it's hardware ID when camera_id is not used (camera_id = -1).
+  # To get a list of available cameras, run `libcamera-hello --list-cameras` to get something like this:
+  #   /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60
+  #   /base/axi/pcie@1000120000/rp1/i2c@88000/ov9281@60
+  # You can use any part of the camera's hardware ID as the camera_name, as long as it is unique among all cameras on the system.
+  #   if you only have one camera, you can put leave this as empty string (""), so it matches the first camera found on the system.
+  #   if you have different camera models, then the model name is a good choice (such as ov9281)
+  #   if you have multiple cameras of the same type, then you can use the address (such as i2c@80000)
+  #   if you want to be really sure to use a specific camera, you can use the full hardware ID (such as /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60)
+  camera_name: ""

--- a/config/camera_right.yaml
+++ b/config/camera_right.yaml
@@ -1,17 +1,12 @@
 libcamera_ros_driver:
 
-  # This is the camera index in the list of cameras returned by libcamera.
-  # The order of cameras in the list is not stable, so this should never be used and is here just for backwards compatibility.
-  # Use camera_name instead.
-  camera_id: 1
-
-  # Camera name is the key used to identify the camera based on it's hardware ID when camera_id is not used (camera_id = -1).
-  # To get a list of available cameras, run `libcamera-hello --list-cameras` to get something like this:
+  # Camera name is the key used to identify the camera based on it's device tree path.
+  # To get a list of available cameras, run `libcamera-hello --list-cameras`. You will see something like this:
   #   /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60
   #   /base/axi/pcie@1000120000/rp1/i2c@88000/ov9281@60
-  # You can use any part of the camera's hardware ID as the camera_name, as long as it is unique among all cameras on the system.
-  #   if you only have one camera, you can put leave this as empty string (""), so it matches the first camera found on the system.
+  # You can use any part of the camera's device tree path as the camera_name, as long as it is unique among all cameras on the system.
+  #   if you only have one camera, you can leave this as empty string (""), so it matches the first camera found.
   #   if you have different camera models, then the model name is a good choice (such as ov9281)
   #   if you have multiple cameras of the same type, then you can use the address (such as i2c@80000)
-  #   if you want to be really sure to use a specific camera, you can use the full hardware ID (such as /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60)
+  #   if you want to be really sure to use a specific camera, you can use the full device tree path (such as /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60)
   camera_name: ""

--- a/config/camera_right.yaml
+++ b/config/camera_right.yaml
@@ -1,13 +1,17 @@
 libcamera_ros_driver:
 
-  # Per-camera override for the RIGHT sensor of a stereo pair.
-  # Loaded as custom_config (after default.yaml), so these keys win.
-  #
-  # Select by index (robust default): empty camera_name disables name matching,
-  # so camera_id is used verbatim.
-  camera_name: ""
+  # This is the camera index in the list of cameras returned by libcamera.
+  # The order of cameras in the list is not stable, so this should never be used and is here just for backwards compatibility.
+  # Use camera_name instead.
   camera_id: 1
 
-  # Alternative: select by the unique i2c path (see config.txt dtoverlay cam0/cam1).
-  # Comment out the two lines above and use, e.g.:
-  # camera_name: "i2c@88000"
+  # Camera name is the key used to identify the camera based on it's hardware ID when camera_id is not used (camera_id = -1).
+  # To get a list of available cameras, run `libcamera-hello --list-cameras` to get something like this:
+  #   /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60
+  #   /base/axi/pcie@1000120000/rp1/i2c@88000/ov9281@60
+  # You can use any part of the camera's hardware ID as the camera_name, as long as it is unique among all cameras on the system.
+  #   if you only have one camera, you can put leave this as empty string (""), so it matches the first camera found on the system.
+  #   if you have different camera models, then the model name is a good choice (such as ov9281)
+  #   if you have multiple cameras of the same type, then you can use the address (such as i2c@80000)
+  #   if you want to be really sure to use a specific camera, you can use the full hardware ID (such as /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60)
+  camera_name: ""

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -4,8 +4,21 @@ libcamera_ros_driver:
   ## |                    compulsory parameters                   #
   ## --------------------------------------------------------------
 
-  camera_name: "ov9281" # if the camera_name is not defined, the id is used
-  camera_id: 0
+  # This is the camera index in the list of cameras returned by libcamera.
+  # The order of cameras in the list is not stable, so this should never be used and is here just for backwards compatibility.
+  # Use camera_name instead.
+  camera_id: -1
+
+  # Camera name is the key used to identify the camera based on it's hardware ID when camera_id is not used (camera_id = -1).
+  # To get a list of available cameras, run `libcamera-hello --list-cameras` to get something like this:
+  #   /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60
+  #   /base/axi/pcie@1000120000/rp1/i2c@88000/ov9281@60
+  # You can use any part of the camera's hardware ID as the camera_name, as long as it is unique among all cameras on the system.
+  #   if you only have one camera, you can put leave this as empty string (""), so it matches the first camera found on the system.
+  #   if you have different camera models, then the model name is a good choice (such as ov9281)
+  #   if you have multiple cameras of the same type, then you can use the address (such as i2c@80000)
+  #   if you want to be really sure to use a specific camera, you can use the full hardware ID (such as /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60)
+  camera_name: ""
 
   stream_role: "still" # [raw, still, video, viewfinder]
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -4,20 +4,15 @@ libcamera_ros_driver:
   ## |                    compulsory parameters                   #
   ## --------------------------------------------------------------
 
-  # This is the camera index in the list of cameras returned by libcamera.
-  # The order of cameras in the list is not stable, so this should never be used and is here just for backwards compatibility.
-  # Use camera_name instead.
-  camera_id: -1
-
-  # Camera name is the key used to identify the camera based on it's hardware ID when camera_id is not used (camera_id = -1).
-  # To get a list of available cameras, run `libcamera-hello --list-cameras` to get something like this:
+  # Camera name is the key used to identify the camera based on it's device tree path.
+  # To get a list of available cameras, run `libcamera-hello --list-cameras`. You will see something like this:
   #   /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60
   #   /base/axi/pcie@1000120000/rp1/i2c@88000/ov9281@60
-  # You can use any part of the camera's hardware ID as the camera_name, as long as it is unique among all cameras on the system.
-  #   if you only have one camera, you can put leave this as empty string (""), so it matches the first camera found on the system.
+  # You can use any part of the camera's device tree path as the camera_name, as long as it is unique among all cameras on the system.
+  #   if you only have one camera, you can leave this as empty string (""), so it matches the first camera found.
   #   if you have different camera models, then the model name is a good choice (such as ov9281)
   #   if you have multiple cameras of the same type, then you can use the address (such as i2c@80000)
-  #   if you want to be really sure to use a specific camera, you can use the full hardware ID (such as /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60)
+  #   if you want to be really sure to use a specific camera, you can use the full device tree path (such as /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60)
   camera_name: ""
 
   stream_role: "still" # [raw, still, video, viewfinder]

--- a/launch/camera.launch.py
+++ b/launch/camera.launch.py
@@ -97,17 +97,17 @@ def generate_launch_description():
 
     # #} end of environment variables
 
-    # #{ camera_name
+    # #{ suffix
 
-    camera_name = LaunchConfiguration('camera_name')
+    suffix = LaunchConfiguration('suffix')
 
     ld.add_action(DeclareLaunchArgument(
-        'camera_name',
+        'suffix',
         default_value='front',
-        description='Name of the camera'
+        description='Suffix for node, frame and container names, such as rpi_camera_SUFFIX.'
     ))
 
-    # #} end of camera_name
+    # #} end of suffix
 
     # #{ custom_config
 
@@ -172,11 +172,11 @@ def generate_launch_description():
         package=pkg_name,
         plugin='libcamera_ros_driver::LibcameraRosDriver',
         namespace=uav_name,
-        name=['rpi_camera_', camera_name],
+        name=['rpi_camera_', suffix],
 
         parameters=[
             {'use_sim_time': use_sim_time},
-            {'frame_id': [uav_name, "/rpi_camera_", camera_name]},
+            {'frame_id': [uav_name, "/rpi_camera_", suffix]},
             {'calib_url': calib_url},
             {'config': this_pkg_path + '/config/default.yaml'},
             {'custom_config': custom_config},
@@ -207,7 +207,7 @@ def generate_launch_description():
 
     standalone_container = ComposableNodeContainer(
         namespace=uav_name,
-        name=['rpi_camera_', camera_name, "_container"],
+        name=['rpi_camera_', suffix, "_container"],
         package='rclcpp_components',
         executable='component_container_isolated',
         output='screen',

--- a/launch/camera.launch.py
+++ b/launch/camera.launch.py
@@ -104,7 +104,7 @@ def generate_launch_description():
     ld.add_action(DeclareLaunchArgument(
         'camera_name',
         default_value='front',
-        description='Name of the camera (used to select which camera to use if multiple are present)'
+        description='Name of the camera'
     ))
 
     # #} end of camera_name

--- a/src/libcamera_ros_driver.cpp
+++ b/src/libcamera_ros_driver.cpp
@@ -268,66 +268,55 @@ namespace libcamera_ros_driver
       exit(1);
     }
 
-    // When camera name is specified, the camera id is automatically extracted.
-    // This only works if the cameras have unique IDs.
-    // When using two identical cameras, define them like this in /boot/firmware/config.txt
-    //
-    // dtoverlay=ov9281
-    // dtoverlay=ov9281,cam0
-    // dtoverlay=ov9281,cam1
-    //
-    // ... this will make them have a unique ID.
-    // Then do `sudo rpicam-hello --list-cameras` and you will get two unique IDs, like:
-    //
-    // /base/axi/pcie@120000/rp1/i2c@80000/ov9281@60
-    // /base/axi/pcie@120000/rp1/i2c@88000/ov9281@60
 
-    if (!camera_name.empty())
+    // Print a list of available cameras and their IDs (addresses)
+    RCLCPP_INFO_STREAM(this_node().get_logger(), "Available cameras:");
+    for (size_t i = 0; i < camera_manager_->cameras().size(); i++)
     {
+      auto camera = camera_manager_->cameras().at(i);
+      auto msg = std::format("  {}: {}", i, camera->id());
 
-      std::vector<std::string> available_cameras;
+      RCLCPP_INFO_STREAM(this_node().get_logger(), msg);
+    }
 
-      RCLCPP_INFO_STREAM(this_node().get_logger(), "Available cameras:");
-
+    // If camera_id is set, use that, otherwise try to find it by camera_name
+    if (camera_id == -1)
+    {
       for (size_t i = 0; i < camera_manager_->cameras().size(); i++)
       {
-        available_cameras.push_back(camera_manager_->cameras().at(i)->id());
-      }
-
-      for (size_t i = 0; i < available_cameras.size(); i++)
-      {
-
-        if (available_cameras.at(i).find(camera_name) != std::string::npos)
+        auto camera = camera_manager_->cameras().at(i);
+        if (camera->id().find(camera_name) != std::string::npos)
         {
-          RCLCPP_INFO_STREAM(this_node().get_logger(), "found camera: " << camera_name << " index: " << i << " at: " << available_cameras.at(i));
+          auto msg = std::format("Found camera '{}' by name ({})", camera_name, camera->id());
+          RCLCPP_INFO_STREAM(this_node().get_logger(), msg);
           camera_id = i;
           break;
         }
       }
     }
 
-    if (camera_id >= int(camera_manager_->cameras().size()))
+    // If camera_id is still -1, then the camera was not found by name
+    if (camera_id == -1)
     {
-      RCLCPP_INFO_STREAM(this_node().get_logger(), *camera_manager_);
-      RCLCPP_ERROR_STREAM(this_node().get_logger(), "camera with id " << camera_name << " does not exist");
+      auto msg = std::format("Camera with name '{}' does not exist!", camera_name);
+      RCLCPP_ERROR_STREAM(this_node().get_logger(), msg);
+      rclcpp::shutdown();
+      exit(1);
+    }
+
+    // Check if camera_id is within the range of available cameras
+    if (camera_id < 0 || camera_id >= static_cast<int>(camera_manager_->cameras().size()))
+    {
+      auto msg = std::format("Camera with id (index) {} does not exist!", camera_id);
+      RCLCPP_ERROR_STREAM(this_node().get_logger(), msg);
       rclcpp::shutdown();
       exit(1);
     }
 
     camera_ = camera_manager_->cameras().at(camera_id);
-    RCLCPP_INFO_STREAM(this_node().get_logger(), "Use camera by id: " << camera_id);
-
-    if (!camera_)
-    {
-      RCLCPP_INFO_STREAM(this_node().get_logger(), *camera_manager_);
-      RCLCPP_ERROR_STREAM(this_node().get_logger(), "camera with name " << camera_name << " does not exist");
-      rclcpp::shutdown();
-      exit(1);
-    }
-
     if (camera_->acquire())
     {
-      RCLCPP_ERROR(node_->get_logger(), "Failed to acquire camera");
+      RCLCPP_ERROR(node_->get_logger(), "Failed to acquire camera. If you have multiple cameras check if camera_name is unique.");
       rclcpp::shutdown();
       return;
     }

--- a/src/libcamera_ros_driver.cpp
+++ b/src/libcamera_ros_driver.cpp
@@ -231,7 +231,6 @@ namespace libcamera_ros_driver
     std::string stream_role;
     std::string pixel_format;
     std::string calib_url;
-    int camera_id;
     int resolution_width;
     int resolution_height;
 
@@ -241,7 +240,6 @@ namespace libcamera_ros_driver
     param_loader.setPrefix("libcamera_ros_driver/");
 
     param_loader.loadParam("camera_name", camera_name);
-    param_loader.loadParam("camera_id", camera_id);
     param_loader.loadParam("stream_role", stream_role);
     param_loader.loadParam("pixel_format", pixel_format);
     param_loader.loadParam("resolution/width", resolution_width);
@@ -268,8 +266,7 @@ namespace libcamera_ros_driver
       exit(1);
     }
 
-
-    // Print a list of available cameras and their IDs (addresses)
+    // Print a list of available cameras and their device tree paths (such as /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60)
     RCLCPP_INFO_STREAM(this_node().get_logger(), "Available cameras:");
     for (size_t i = 0; i < camera_manager_->cameras().size(); i++)
     {
@@ -279,41 +276,28 @@ namespace libcamera_ros_driver
       RCLCPP_INFO_STREAM(this_node().get_logger(), msg);
     }
 
-    // If camera_id is set, use that, otherwise try to find it by camera_name
-    if (camera_id == -1)
+    int camera_index = -1;
+    for (size_t i = 0; i < camera_manager_->cameras().size(); i++)
     {
-      for (size_t i = 0; i < camera_manager_->cameras().size(); i++)
+      auto camera = camera_manager_->cameras().at(i);
+      if (camera->id().find(camera_name) != std::string::npos)
       {
-        auto camera = camera_manager_->cameras().at(i);
-        if (camera->id().find(camera_name) != std::string::npos)
-        {
-          auto msg = std::format("Found camera '{}' by name ({})", camera_name, camera->id());
-          RCLCPP_INFO_STREAM(this_node().get_logger(), msg);
-          camera_id = i;
-          break;
-        }
+        auto msg = std::format("Found camera '{}'. Device tree path: {}", camera_name, camera->id());
+        RCLCPP_INFO_STREAM(this_node().get_logger(), msg);
+        camera_index = i;
+        break;
       }
     }
 
-    // If camera_id is still -1, then the camera was not found by name
-    if (camera_id == -1)
+    if (camera_index == -1)
     {
-      auto msg = std::format("Camera with name '{}' does not exist!", camera_name);
+      auto msg = std::format("Camera name '{}' does not exist!", camera_name);
       RCLCPP_ERROR_STREAM(this_node().get_logger(), msg);
       rclcpp::shutdown();
       exit(1);
     }
 
-    // Check if camera_id is within the range of available cameras
-    if (camera_id < 0 || camera_id >= static_cast<int>(camera_manager_->cameras().size()))
-    {
-      auto msg = std::format("Camera with id (index) {} does not exist!", camera_id);
-      RCLCPP_ERROR_STREAM(this_node().get_logger(), msg);
-      rclcpp::shutdown();
-      exit(1);
-    }
-
-    camera_ = camera_manager_->cameras().at(camera_id);
+    camera_ = camera_manager_->cameras().at(camera_index);
     if (camera_->acquire())
     {
       RCLCPP_ERROR(node_->get_logger(), "Failed to acquire camera. If you have multiple cameras check if camera_name is unique.");


### PR DESCRIPTION
## Summary

This PR cleans up the code for selecting which camera to connect  to and clarifies the meaning of parameters `camera_name` and `camera_id`.

## The problem

While using 2 of the same camera (OV9281) I noticed that when rebooting the front and back cameras would sometimes switch places.
I tracked the issue to poor naming, documentation and examples for the `camera_id` and `camera_name` parameters in this driver.

I assumed `camera_id` is somehow derived from the physical port/address where the camera is connected to the Pi and that once set it will never change, and `camera_name` some kind of internal memory on the camera where we can put custom text and then identify the camera by that.

Turns out that `camera_id` is not actually an id but an index in the list of cameras supplied by `libcamera`. The order of cameras in this list is not constant.
 `camera_name` is actually the key for substring search through the camera id supplied by `libcamera`, such as `/base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60`.

## Additional breaking changes I'd like to make

1. Since `camera_id` is not stable I think it should never be used and the parameter should be removed. This is a breaking change but whoever is using `camera_id` has a broken setup anyway.
2. In the `camera.lauch.py` file there is a launch argument that is also called `camera_name`, but is only used for naming nodes and so on. This should be renamed, so it is not confused with the parameter with the same name. 

Please let me know if I can remove `camera_id` and what should I call the nodes and topics created by the launch file (maybe just `rpi_camera` instead of `rpi_camera_NAME`?)
