### PR TITLE
Cleanup info about pixel_format and publish_mono8

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,25 +167,7 @@ custom_config (per-camera)  >  config/default.yaml  >  launch-file ROS params (f
 `custom_config` is loaded *before* `default.yaml`, so it only needs the keys that differ
 (typically the sensor selection and per-camera tweaks); everything else falls through.
 
-### Key parameters
-
-| Parameter | Default | Notes |
-|---|---|---|
-| `stream_role` | `video` | `[raw, still, video, viewfinder]`. Use **`video`**, it's the role that yields a node-consumable format on this sensor. (`raw` exposes only packed formats this node can't decode.) |
-| `pixel_format` | `R8` | On the OV9281 (10-bit mono) every mono request is **promoted to R16** by the pipeline, mono is treated as raw, and the sensor has no 8-bit mode. So you get MONO16 regardless. |
-| `resolution/{width,height}` | `1280×800` | sensor native |
-| `use_ros_time` | `true` | stamp on ROS clock (keeps cross-process stamps comparable) |
-| **`publish_mono8`** | `true` | **Narrow MONO16 → MONO8 before publishing.** Halves payload, transport, and the subscriber's copy. Lossy (drops the low bits feature trackers ignore). Only acts on a mono16 source. |
-| **`mono8_shift`** | `8` | Bits shifted right when narrowing. PiSP packs samples **MSB-aligned**, so `8` (top byte) is correct. **Image too dark/bright → tune this** (no rebuild). Clamped to `[0,15]`. |
-| **`dmabuf_sync`** | `true` | Cache invalidate/flush around the CPU read. Required for non-coherent buffers; on the Pi 5 the buffers are coherent, so `false` is safe **if the image stays clean** and saves a little CPU. |
-| `control/fps` | `60` | sets `FrameDurationLimits = 1e6/fps` µs. Keep `exposure_time` below the frame period or fps silently drops. |
-| `control/ae_enable` | - | **`false`** recommended for VIO / VI-SLAM (constant exposure). |
-| `control/awb_enable` | - | **`false`** (pointless on a mono sensor). |
-| `control/exposure_time` | - | µs, fixed when AE off. Too short → black image. |
-| `control/analogue_gain` | - | fixed gain when AE off; raise if the image is dark. |
-
-The full set of libcamera control parameters (brightness, sharpness, gains, metering, …) is
-documented inline in [`config/default.yaml`](config/default.yaml).
+The full set of libcamera control parameters is documented inline in [`config/default.yaml`](config/default.yaml).
 
 ---
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,5 +1,4 @@
 libcamera_ros_driver:
-
   ## --------------------------------------------------------------
   ## |                    compulsory parameters                   #
   ## --------------------------------------------------------------
@@ -15,22 +14,22 @@ libcamera_ros_driver:
   #   if you want to be really sure to use a specific camera, you can use the full device tree path (such as /base/axi/pcie@1000120000/rp1/i2c@80000/ov9281@60)
   camera_name: ""
 
-  stream_role: "still" # [raw, still, video, viewfinder]
+  # This defines how the camera will be used. It influences the available pixel formats, resolution, etc.
+  # 'video' or 'raw' are most likely to support formats you care about.
+  stream_role: "video" # [raw, still, video, viewfinder]
 
-  # Available output formats (camera-offered AND driver-supported) with per-pixel cost.
-  # Fewer bytes/pixel => less CPU on the per-frame copy and less bandwidth on the wire.
-  # NOTE: ov9281 is a 10-bit MONO sensor. On the Pi5/PiSP pipeline, R8 is silently
-  #       promoted to R16 (10-bit sensor data unpacked into 16-bit). See "Stream
-  #       configuration adjusted" in the startup log to confirm what was negotiated.
-  # docs: https://libcamera.org/api-html/build_2include_2libcamera_2formats_8h_source.html
-  pixel_format: "RGB888"    # 3 B/px -> BGR8 ; ISP gamma-corrected, display-ready, highest CPU
-  # pixel_format: "BGR888"    # 3 B/px -> RGB8 ; ISP gamma-corrected, display-ready
-  # pixel_format: "YUYV"      # 2 B/px -> YUV422 ; Y plane is gamma-corrected 8-bit gray (display-ready, low CPU)
-  # pixel_format: "R16"       # 2 B/px -> MONO16 ; LINEAR 10-bit data (looks dark in MONO16 viewers; ideal for algorithms)
-  # pixel_format: "R8"        # 1 B/px -> MONO8 ; lowest CPU, but PiSP promotes it to R16 on this sensor
-  # pixel_format: "XRGB8888"  # 4 B/px -> BGRA8 ; highest CPU
-  # pixel_format: "SRGGB8"    # 1 B/px -> raw Bayer8  (not meaningful on a mono sensor)
-  # pixel_format: "SRGGB16"   # 2 B/px -> raw Bayer16 (not meaningful on a mono sensor)
+  # List of common pixel formats. All supported formats will be printed in the startup log.
+  # Note that on RPi5, the image processing pipeline will silently change 8-bit pixel formats to 16 bit (see https://forums.raspberrypi.com/viewtopic.php?t=381311),
+  # so even if you select R8 on a 8-bit mono sensor, you will get R16 on the topic. To avoid confusion it is recommended to just use R16 instead of R8.
+  # alternatively you can use the "publish_mono8" option below to narrow the R16 down to R8 in the driver, before publishing.
+  pixel_format: "RGB888"
+  # pixel_format: "BGR888"
+  # pixel_format: "YUYV"
+  # pixel_format: "R16"       # MONO16
+  # pixel_format: "R8"        # MONO8
+  # pixel_format: "XRGB8888"
+  # pixel_format: "SRGGB8"
+  # pixel_format: "SRGGB16"
 
   resolution:
     width: 1280
@@ -38,14 +37,11 @@ libcamera_ros_driver:
 
   use_ros_time: true # if set to true, the time stamps of the output camera images will be expressed in the current ROS time, rather than the time given by the camera sensor
 
-  # Narrow a MONO16 source (R16) down to MONO8 in the driver, BEFORE publishing. Halves the
-  # serialized payload / wire bandwidth / subscriber copy -- the only byte reduction possible
-  # on this sensor, since mono is forced to raw R16 by the pipeline (R8 is promoted, see above).
-  # Only takes effect when the negotiated encoding is mono16 (otherwise ignored with a warning).
-  # Lossy: drops the low bits the 8-bit consumer ignores anyway (fine for VIO/feature tracking).
-  publish_mono8: true
-  mono8_shift: 8 # bits to shift right when narrowing.
-                 # Image too dark/bright? This is the knob (no rebuild needed).
+  # Narrow a MONO16 source (R16) down to MONO8 before publishing. This reduces the amount of data on the topic, but might actually increase CPU usage depending
+  # on how you use this driver. In case you are mounting your application and this driver into the same container, it will be significantly faster to just output MONO16.
+  # Narrowing is performed by shifting the pixel values by mono8_shift bits to the right, which can cause data loss. Be careful when using this option and measure if you actually need it.
+  publish_mono8: false
+  mono8_shift: 8
 
   # dmabuf cache invalidate/flush around each frame's CPU read. Required for correct reads of
   # NON-coherent capture buffers. If the Pi's buffers are coherent, this is pure CPU overhead

--- a/src/libcamera_ros_driver.cpp
+++ b/src/libcamera_ros_driver.cpp
@@ -109,10 +109,8 @@ namespace libcamera_ros_driver
     uint32_t img_step_ = 0;
     uint32_t src_stride_ = 0; // input row stride in bytes (for mono16->mono8 narrowing)
 
-    // opt-in: publish MONO8 by narrowing a MONO16 frame. Halves the serialized payload for
-    // consumers (e.g. VIO) that only use 8-bit greyscale. Default off keeps the raw R16 output.
     bool mono8_ = false;
-    int mono8_shift_ = 8; // PiSP unpacks raw MSB-aligned, so the top byte (>>8) is the image
+    int mono8_shift_ = 8;
 
     // dmabuf cache invalidate/flush around the CPU read of each frame. Necessary for correct
     // reads of NON-coherent capture buffers; pure overhead (cache ops over the whole frame) if
@@ -247,7 +245,7 @@ namespace libcamera_ros_driver
     param_loader.loadParam("use_ros_time", _use_ros_time_);
     param_loader.loadParam("publish_mono8", mono8_, false);
     param_loader.loadParam("mono8_shift", mono8_shift_, 8);
-    mono8_shift_ = std::clamp(mono8_shift_, 0, 15); // a uint16 shift outside [0,15] is UB
+    mono8_shift_ = std::clamp(mono8_shift_, 0, 15);
     param_loader.loadParam("dmabuf_sync", dmabuf_sync_, true);
 
     if (!param_loader.loadedSuccessfully())
@@ -498,11 +496,11 @@ namespace libcamera_ros_driver
     src_stride_ = scfg.stride;
     img_step_ = scfg.stride;
 
-    // mono8 narrowing only applies to a 16-bit mono source; otherwise fall back to passthrough
+    // mono8 narrowing only applies to a 16-bit mono source
     if (mono8_ && encoding_ == "mono16")
     {
       encoding_ = "mono8";
-      img_step_ = img_width_; // 1 byte/pixel, tightly packed
+      img_step_ = img_width_;
       RCLCPP_INFO_STREAM(node_->get_logger(), "publish_mono8: narrowing MONO16 -> MONO8 (shift " << mono8_shift_ << ")");
     } else if (mono8_)
     {


### PR DESCRIPTION
## Summary

This PR started with cleaning up the text about `pixel_format` and `publish_mono8` parameters but grew into benchmarking different configuration options to find how to minimize the CPU usage.

## Motivation

Nobody caught that the texts about "OV9281 being a 10 bit sensor whose outputs gets promoted to 16 bit and has to be shifted to 8 because it cannot natively output 8 bit" (<https://github.com/ctu-mrs/libcamera_ros_driver/blob/ros2/README.md?plain=1#L197>) are wrong.

OV9281 supports both 8 and 10 bit output, but the image processing pipeline on the RPi5 will internally change it to 16 bit (see <https://forums.raspberrypi.com/viewtopic.php?t=381311>, <https://github.com/raspberrypi/libcamera/issues/256>), so no matter if you select `pixel_format: R8` or `pixel_format: R16` you will get MONO16 on the ROS topic.
In both cases the sensor output will be `Y10_1X10`, which is a 10-bit format.
The data is left aligned (10 most significant bits).

The current solution for minimizing CPU usage is to convert 16 bit elements with 10 bits of sensor value to 8 bit data (MONO8) by shifting them 8 bits to the right (thus losing 2 bits of data).
While well intentioned, this solution is not always faster than just publishing MONO16 to the ROS topic and letting the client handle conversion with OpenCV or similar.

## CPU usage measurements

*Note: these measurements are a bit rough and cannot be used as absolute values, but we can compare different settings to see which combination is best.*

The goal was to find out what's the best combination of options `pixel_format` and `publish_mono8` for my application (Ultraloc), and how best to connect my application and the camera driver.

I measured total CPU usage of the entire RPi 5 (all cores combined) when both the camera driver and Ultraloc are running.

Test environment:

- RPi5 overclocked to 2.7 GHz
- in Ultraloc I use `toCvShare(msg, sensor_msgs::image_encodings::MONO8)` to convert the input to MONO8 if it isn't yet. I think this is reasonable to include in pretty much all applications, since it makes the code more robust, and more importantly for this test, it compares whether it is better to do `MONO16`->`MONO8` conversion in the driver or in the application.
- I am using two OV9281 cameras (mono sensor).
- both cameras were recording at 1280x800, 60 fps

### Compiling with `-O2`

For the tests in the table 1 and 2 I compiled Ultraloc and libcamera_ros_driver with `RelWithDebInfo`, which uses `-O2` optimizations.

**Table 1: composable nodes (driver and application in the same process), RelWithDebInfo:**

| `pixel_format` | `publish_mono8: true` | `publish_mono8: false` |
| -------------- | --------------------- | ---------------------- |
| RGB888         | 25 %                  | 28 %                   |
| BRG888         | 26 %                  | 28 %                   |
| YUYV           | 22 %                  | 20 %                   |
| R16            | 33 %                  | 17 %                   |
| R8             | 48 %                  | 18 %                   |
| XRGB8888       | 37 %                  | 40 %                   |
| SRGGB8         | 49 %                  | 20 %                   |
| SRGGB16        | 49 %                  | 19 %                   |

**Table 2: no composable nodes (drivers and application running in separate processes), RelWithDebInfo:**

| `pixel_format` | `publish_mono8: true` | `publish_mono8: false` |
| -------------- | --------------------- | ---------------------- |
| RGB888         | 91 %                  | 91 %                   |
| BRG888         | 90 %                  | 90 %                   |
| YUYV           | 85 %                  | 87 %                   |
| R16            | 65 %                  | 38 %                   |
| R8             | 60 %                  | 34 %                   |
| XRGB8888       | 90 %                  | 88 %                   |
| SRGGB8         | 65 %                  | 34 %                   |
| SRGGB16        | 65 %                  | 39 %                   |

### Compiling with `-O3`

After performing the measurements in table 1 and 2 I double checked my results on coworker's setup, which performed very differently.
After a lot of searching we tracked down the difference to the fact that he was compiling with `Release`, which uses `-O3` optimizations, so I re-did my measurements with `-O3` optimizations as well. These are shown in tables 3 and 4.

**Table 3: composable nodes (driver and application in the same process), RelWithDebInfo and -O3 optimization:**

| `pixel_format` | `publish_mono8: true` | `publish_mono8: false` |
| -------------- | --------------------- | ---------------------- |
| RGB888         | 30 %                  | 28 %                   |
| BRG888         | 28 %                  | 28 %                   |
| YUYV           | 45 %                  | 43 %                   |
| R16            | 23 %                  | 18 %                   |
| R8             | 27 %                  | 18 %                   |
| XRGB8888       | 40 %                  | 46 %                   |
| SRGGB8         | 26 %                  | 21 %                   |
| SRGGB16        | 26 %                  | 21 %                   |

**Table 4: no composable nodes (drivers and application running in separate processes), RelWithDebInfo and -O3 optimization:**

| `pixel_format` | `publish_mono8: true` | `publish_mono8: false` |
| -------------- | --------------------- | ---------------------- |
| RGB888         | 90 %                  | 90 %                   |
| BRG888         | 90 %                  | 90 %                   |
| YUYV           | 88 %                  | 88 %                   |
| R16            | 37 %                  | 38 %                   |
| R8             | 36 %                  | 39 %                   |
| XRGB8888       | 89 %                  | 90 %                   |
| SRGGB8         | 35 %                  | 37 %                   |
| SRGGB16        | 35 %                  | 41 %                   |

### More efficient conversion to MONO8

In most cases `publish_mono8: true` performs worse than `false`, but when not using composable nodes it does actually perform a few percent better (table 4, R8).
For this reason I decided to try an improved version of `publish_mono8`, which  always takes the 8 most significant bits instead of having a parameter for the shift amount.
The results for this are shown in tables 5 and 6. Since it only affects R8 and R16 I only did measurements for those.

**Table 5: Take top byte, composable nodes (driver and application in the same process), RelWithDebInfo and -O3 optimization:**

| `pixel_format` | `publish_mono8: true` | `publish_mono8: false` |
| -------------- | --------------------- | ---------------------- |
| R16            | 24 %                  | 18 %                   |
| R8             | 24 %                  | 17 %                   |

**Table 6: Take top byte, no composable nodes (drivers and application running in separate processes), RelWithDebInfo and -O3 optimization:**

| `pixel_format` | `publish_mono8: true` | `publish_mono8: false` |
| -------------- | --------------------- | ---------------------- |
| R16            | 32 %                  | 38 %                   |
| R8             | 33 %                  | 38 %                   |

## OpenCV for converting to MONO8

I also tried using OpenCV to convert to MONO8 in the driver, but it performs worse than the shifts we have there now. I am not entirely sure why this is the case, perhaps my implementation is bad:

```cpp
cv::Mat input(static_cast<int>(height), static_cast<int>(width), CV_16UC1, const_cast<uint8_t*>(src), src_stride);
cv::Mat output(static_cast<int>(height), static_cast<int>(width), CV_8UC1, msg->data.data(), width);
input.convertTo(output, CV_8U, 1.0 / 256.0);

```

**Table 7: OpenCV, composable nodes (driver and application in the same process), RelWithDebInfo and -O3 optimization:**

| `pixel_format` | `publish_mono8: true` | `publish_mono8: false` |
| -------------- | --------------------- | ---------------------- |
| R16            | 28 %                  | 17 %                   |
| R8             | 27 %                  | 17 %                   |

**Table 8: OpenCV, no composable nodes (drivers and application running in separate processes), RelWithDebInfo and -O3 optimization:**

| `pixel_format` | `publish_mono8: true` | `publish_mono8: false` |
| -------------- | --------------------- | ---------------------- |
| R16            | 43  %                  | 38 %                   |
| R8             |  42 %                  | 37 %                   |

## Results

1. composable nodes make a huge difference (2-3 times lower CPU consumption)
2. `-O3` optimization sometimes makes a significant difference, usually for the better, but sometimes worse (YUYV format with composable nodes)
3. for lowest CPU consumption you should use composable nodes and set `publish_mono8: false`. If needed you can convert to MONO8 with OpenCV in the application.
4. if you really cannot use composable nodes it does make sense to convert to MONO8 before publishing the data, but only if compiling with `-O3`. Even then the CPU usage will be significantly higher than with composable nodes.
5. For some reason `toCvShare` in consumer application is much faster than `cv::Mat convertTo`

## Next steps

The significantly lower CPU usage (15 - 20 % in my case) is large enough that this driver should **always** be used as a composable node.

If it is also reasonable to expect the consumer application to have something like `toCvShare(msg, sensor_msgs::image_encodings::MONO8)` to ensure correct datatype, then the parameters `publish_mono8` and `mono8_shift` can be removed, otherwise a more efficient MONO16 -> MONO8 implementation should be used.
